### PR TITLE
refactor(swarm_team): wrap SwarmTeam plan execution result into an artifact model

### DIFF
--- a/examples/software_team/planner.py
+++ b/examples/software_team/planner.py
@@ -47,10 +47,11 @@ IMPORTANT: The JSON Response must:
 
 ### Task Planning Guidelines
 
-1. Task Consolidation:
-   - Create consolidated, full-featured tasks that encompass related functionality
-   - Aim for 4-8 core tasks that cover the entire feature scope
-   - Each task should represent a complete, testable unit of work
+1. Task Count and Scope:
+   - Create between 1 to 8 core tasks maximum
+   - Focus on essential, high-impact tasks that deliver complete functionality
+   - Consolidate related features into single tasks where appropriate
+   - It's perfectly fine to have fewer tasks (1-4) for simpler projects
 
 2. Task Structure:
    - Each task must include ONLY the fields defined in the schema

--- a/examples/software_team/planner.py
+++ b/examples/software_team/planner.py
@@ -9,7 +9,7 @@ from liteswarm.experimental import AgentPlanner, LiteAgentPlanner
 from liteswarm.types import JSON, LLM, Agent, ContextVariables, TaskDefinition
 
 from .types import FlutterTask, SoftwarePlan
-from .utils import dump_json, find_tag
+from .utils import dump_json, find_json_tag
 
 AGENT_PLANNER_SYSTEM_PROMPT = """
 You are an advanced AI Software Planning Agent designed to assist software engineering teams in project planning and task management. Your primary function is to analyze user queries, decompose them into actionable tasks, and generate a structured plan that can be executed by development teams across various technologies and frameworks.
@@ -131,11 +131,11 @@ def build_planner_user_prompt(prompt: str, context: ContextVariables) -> str:
 
 def parse_planner_response(response: str, context: ContextVariables) -> SoftwarePlan:
     """Parse the response from the planner agent."""
-    json_response = find_tag(response, "json_response")
+    json_response = find_json_tag(response, "json_response")
     if not json_response:
         raise ValueError("No JSON response found")
 
-    return SoftwarePlan.model_validate_json(json_response)
+    return SoftwarePlan.model_validate(json_response)
 
 
 def create_agent_planner(swarm: Swarm, task_definitions: list[TaskDefinition]) -> AgentPlanner:

--- a/examples/software_team/run.py
+++ b/examples/software_team/run.py
@@ -126,12 +126,12 @@ async def main() -> None:
 
         match choice:
             case "1":
-                artifact_result = await team.execute_plan(plan)
-                if artifact_result.error:
-                    print(f"Failed to execute plan: {artifact_result.error}")
+                artifact = await team.execute_plan(plan)
+                if artifact.error:
+                    print(f"Failed to execute plan: {artifact.error}")
                     return
 
-                print_artifact(artifact_result.unwrap("No artifact found"))
+                print_artifact(artifact)
                 break
             case "2":
                 feedback = input("\nEnter your feedback: ")

--- a/examples/software_team/run.py
+++ b/examples/software_team/run.py
@@ -9,7 +9,7 @@ import os
 
 from liteswarm.core import Swarm
 from liteswarm.experimental import SwarmTeam
-from liteswarm.types import ContextVariables
+from liteswarm.types import Artifact, ContextVariables
 from liteswarm.utils import dedent_prompt, enable_logging
 
 from .planner import create_agent_planner
@@ -28,6 +28,49 @@ Create a Flutter TODO list app with the following features:
 3. Local storage for persistence
 4. Clean, modern UI design
 """.strip()
+
+
+def print_artifact(artifact: Artifact) -> None:
+    """Print a detailed, well-formatted view of an execution artifact."""
+    print("\n" + "=" * 50)
+    print(f"🏷  Artifact ID: {artifact.id}")
+    print(f"📊 Status: {_get_status_emoji(artifact.status)} {artifact.status}")
+    print("=" * 50 + "\n")
+
+    if artifact.error:
+        print("❌ Execution Failed")
+        print(f"Error: {artifact.error}")
+        return
+
+    print(f"✅ Successfully completed {len(artifact.task_results)} tasks\n")
+
+    for i, task_result in enumerate(artifact.task_results, 1):
+        agent_id = task_result.assignee.agent.id if task_result.assignee else "unknown"
+        print(f"Task {i}/{len(artifact.task_results)}")
+        print(f"├─ ID: {task_result.task.id}")
+        print(f"├─ Type: {task_result.task.type}")
+        print(f"├─ Title: {task_result.task.title}")
+        print(f"├─ Status: {_get_status_emoji(task_result.task.status)} {task_result.task.status}")
+        print(f"└─ Executed by: 🤖 {agent_id}\n")
+
+        if task_result.output:
+            print("   Output:")
+            for key, value in task_result.output.model_dump().items():
+                print(f"   ├─ {key}: {value}")
+            print()
+
+    print("=" * 50)
+
+
+def _get_status_emoji(status: str) -> str:
+    """Get an appropriate emoji for a status."""
+    return {
+        "COMPLETED": "✅",
+        "FAILED": "❌",
+        "IN_PROGRESS": "⏳",
+        "PENDING": "⏳",
+        "EXECUTING": "🔄",
+    }.get(str(status).upper(), "❓")
 
 
 async def main() -> None:
@@ -88,16 +131,12 @@ async def main() -> None:
 
         match choice:
             case "1":
-                plan_output = await team.execute_plan(plan)
-                if plan_output.error:
-                    print(f"Failed to execute plan: {plan_output.error}")
+                artifact_result = await team.execute_plan(plan)
+                if artifact_result.error:
+                    print(f"Failed to execute plan: {artifact_result.error}")
                     return
 
-                results = plan_output.value or []
-                for result in results:
-                    agent_id = result.assignee.agent.id if result.assignee else "unknown"
-                    print(f"Task {result.task.id} completed by {agent_id}")
-
+                print_artifact(artifact_result.unwrap("No artifact found"))
                 break
             case "2":
                 feedback = input("\nEnter your feedback: ")

--- a/examples/software_team/run.py
+++ b/examples/software_team/run.py
@@ -21,12 +21,7 @@ os.environ["LITESWARM_LOG_LEVEL"] = "DEBUG"
 
 
 USER_PROMPT = """
-Create a Flutter TODO list app with the following features:
-
-1. Add/edit/delete tasks
-2. Mark tasks as complete
-3. Local storage for persistence
-4. Clean, modern UI design
+Create a simple todo list app
 """.strip()
 
 

--- a/examples/software_team/tasks.py
+++ b/examples/software_team/tasks.py
@@ -9,7 +9,7 @@ from typing import Any
 from liteswarm.types import ContextVariables, TaskDefinition
 
 from .types import DebugOutput, DebugTask, FileContent, FlutterOutput, FlutterTask
-from .utils import dump_json, find_tag
+from .utils import dump_json, find_json_tag
 
 FLUTTER_TASK_PROMPT = """
 Implement the following Flutter feature:
@@ -207,20 +207,20 @@ def build_debug_task_prompt(task: DebugTask, context: ContextVariables) -> str:
 
 def parse_flutter_task_response(content: str, context: ContextVariables) -> FlutterOutput:
     """Parse the output of a Flutter task."""
-    json_response = find_tag(content, "json_response")
+    json_response = find_json_tag(content, "json_response")
     if not json_response:
         raise ValueError("No JSON response found")
 
-    return FlutterOutput.model_validate_json(json_response)
+    return FlutterOutput.model_validate(json_response)
 
 
 def parse_debug_task_response(content: str, context: ContextVariables) -> DebugOutput:
     """Parse the output of a Debug task."""
-    json_response = find_tag(content, "json_response")
+    json_response = find_json_tag(content, "json_response")
     if not json_response:
         raise ValueError("No JSON response found")
 
-    return DebugOutput.model_validate_json(json_response)
+    return DebugOutput.model_validate(json_response)
 
 
 def create_flutter_task_definition() -> TaskDefinition:

--- a/examples/software_team/utils.py
+++ b/examples/software_team/utils.py
@@ -7,7 +7,10 @@
 import re
 
 import orjson
-from partial_json_parser.core.api import JSON, parse_json
+from json_repair import repair_json
+
+from liteswarm.types.misc import JSON
+from liteswarm.utils.misc import find_tag_content
 
 from .types import CodeBlock
 
@@ -40,14 +43,6 @@ def extract_code_block(content: str) -> CodeBlock:
     )
 
 
-def load_partial_json(content: str) -> JSON:
-    return parse_json(content, parser=orjson.loads)
-
-
-def dump_partial_json(data: JSON) -> str:
-    return orjson.dumps(data).decode()
-
-
 def dump_json(data: JSON, indent: bool = False) -> str:
     option = orjson.OPT_INDENT_2 if indent else None
     return orjson.dumps(data, option=option).decode()
@@ -57,16 +52,9 @@ def load_json(data: str) -> JSON:
     return orjson.loads(data)
 
 
-def find_tag(text: str, tag: str) -> str | None:
-    """Find and extract content from a tagged section.
+def find_json_tag(text: str, tag: str) -> JSON:
+    tag_content = find_tag_content(text, tag)
+    if not tag_content:
+        return None
 
-    Args:
-        text: Text containing tagged sections.
-        tag: Name of the tag to find.
-
-    Returns:
-        Content between the specified tags, or None if not found.
-    """
-    pattern = re.compile(rf"<{tag}>(.*?)</{tag}>", re.DOTALL)
-    match = pattern.search(text)
-    return match.group(1) if match else None
+    return repair_json(tag_content, return_objects=True)  # type: ignore

--- a/liteswarm/experimental/swarm_team/swarm_team.py
+++ b/liteswarm/experimental/swarm_team/swarm_team.py
@@ -710,9 +710,9 @@ class SwarmTeam:
             task.status = TaskStatus.FAILED
             return Result(error=ValueError("The agent did not return any content"))
 
-        task_result = await self._process_agent_response(
-            assignee=assignee,
+        task_result = await self._process_response(
             response=result.content,
+            assignee=assignee,
             task=task,
             task_definition=task_definition,
             task_context=task_context,

--- a/liteswarm/experimental/swarm_team/swarm_team.py
+++ b/liteswarm/experimental/swarm_team/swarm_team.py
@@ -48,34 +48,36 @@ class SwarmTeam:
                 pr_url: str
                 review_type: str
 
+
             class ReviewOutput(BaseModel):
                 issues: list[str]
                 approved: bool
+
 
             # Create task definition
             review_def = TaskDefinition(
                 task_schema=ReviewTask,
                 task_instructions="Review {task.pr_url}",
-                task_response_format=ReviewOutput
+                task_response_format=ReviewOutput,
             )
 
             # Create team member
             reviewer = TeamMember(
                 id="reviewer-1",
                 agent=Agent(id="review-gpt", llm=LLM(model="gpt-4o")),
-                task_types=[ReviewTask]
+                task_types=[ReviewTask],
             )
 
             # Create and use team
             team = SwarmTeam(
                 swarm=swarm,
                 members=[reviewer],
-                task_definitions=[review_def]
+                task_definitions=[review_def],
             )
 
             # Execute workflow
             plan = await team.create_plan("Review PR #123")
-            results = await team.execute_plan(plan)
+            results = await team.execute_plan(plan.unwrap())
             ```
     """
 
@@ -158,7 +160,7 @@ class SwarmTeam:
                     id="review-1",
                     type="review",
                     title="Review PR",
-                    pr_url="github.com/org/repo/123"
+                    pr_url="github.com/org/repo/123",
                 )
                 context = team._build_task_context(task)
                 # Returns ContextVariables with:
@@ -208,9 +210,9 @@ class SwarmTeam:
                     task=task,
                     task_definition=TaskDefinition(
                         task_schema=Task,
-                        task_instructions="Process {task.title}"
+                        task_instructions="Process {task.title}",
                     ),
-                    task_context=context
+                    task_context=context,
                 )
                 ```
 
@@ -219,13 +221,14 @@ class SwarmTeam:
                 def generate_instructions(task: Task, task_context: ContextVariables) -> str:
                     return f"Process {task.title} with {task_context.get('tool')}"
 
+
                 instructions = team._prepare_instructions(
                     task=task,
                     task_definition=TaskDefinition(
                         task_schema=Task,
                         task_instructions=generate_instructions,
                     ),
-                    task_context=context
+                    task_context=context,
                 )
                 ```
         """
@@ -486,16 +489,12 @@ class SwarmTeam:
         Examples:
             With specific assignee:
                 ```python
-                member = team._select_matching_member(
-                    Task(type="review", assignee="reviewer-1")
-                )
+                member = team._select_matching_member(Task(type="review", assignee="reviewer-1"))
                 ```
 
             Based on task type:
                 ```python
-                member = team._select_matching_member(
-                    Task(type="review")
-                )
+                member = team._select_matching_member(Task(type="review"))
                 ```
         """
         if task.assignee and task.assignee in self.members:
@@ -551,8 +550,8 @@ class SwarmTeam:
                     prompt="Review authentication changes in PR #123",
                     context=ContextVariables(
                         pr_url="github.com/org/repo/123",
-                        focus_areas=["security", "performance"]
-                    )
+                        focus_areas=["security", "performance"],
+                    ),
                 )
                 ```
         """
@@ -666,7 +665,7 @@ class SwarmTeam:
                         id="review-1",
                         title="Security review of auth changes",
                         pr_url="github.com/org/repo/123",
-                        review_type="security"
+                        review_type="security",
                     )
                 )
 

--- a/liteswarm/experimental/swarm_team/swarm_team.py
+++ b/liteswarm/experimental/swarm_team/swarm_team.py
@@ -319,10 +319,10 @@ class SwarmTeam:
 
         return response_format.model_validate(decoded_object)
 
-    async def _process_agent_response(
+    async def _process_response(
         self,
-        assignee: TeamMember,
         response: str,
+        assignee: TeamMember,
         task: Task,
         task_definition: TaskDefinition,
         task_context: ContextVariables,
@@ -334,8 +334,8 @@ class SwarmTeam:
         response repair agent.
 
         Args:
-            assignee: Team member who executed the task.
             response: Raw agent response after task execution.
+            assignee: Team member who executed the task.
             task: Executed task.
             task_definition: Task type definition.
             task_context: Execution context.
@@ -352,24 +352,25 @@ class SwarmTeam:
                     issues: list[str]
                     approved: bool
 
+
                 task = Task(id="review-1", type="review", title="Review PR")
                 assignee = TeamMember(
                     id="reviewer-1",
                     agent=Agent(id="review-gpt"),
-                    task_types=[ReviewTask]
+                    task_types=[ReviewTask],
                 )
                 task_def = TaskDefinition(
                     task_schema=ReviewTask,
-                    task_response_format=ReviewOutput
+                    task_response_format=ReviewOutput,
                 )
 
                 response = '{"issues": [], "approved": true}'
-                result = await team._process_agent_response(
-                    assignee=assignee,
+                result = await team._process_response(
                     response=response,
+                    assignee=assignee,
                     task=task,
                     task_definition=task_def,
-                    task_context=context
+                    task_context=context,
                 )
                 # Returns Result with TaskResult containing:
                 # - task details
@@ -386,12 +387,12 @@ class SwarmTeam:
                     'approved': false,  # Extra comma
                 }
                 '''
-                result = await team._process_agent_response(
-                    assignee=assignee,
+                result = await team._process_response(
                     response=response,
+                    assignee=assignee,
                     task=task,
                     task_definition=task_def,
-                    task_context=context
+                    task_context=context,
                 )
                 # Returns repaired and validated TaskResult
                 ```
@@ -400,15 +401,15 @@ class SwarmTeam:
                 ```python
                 task_def = TaskDefinition(
                     task_schema=Task,
-                    task_response_format=None  # No format specified
+                    task_response_format=None,  # No format specified
                 )
                 response = "Task completed successfully"
-                result = await team._process_agent_response(
-                    assignee=assignee,
+                result = await team._process_response(
                     response=response,
+                    assignee=assignee,
                     task=task,
                     task_definition=task_def,
-                    task_context=context
+                    task_context=context,
                 )
                 # Returns TaskResult with raw content
                 ```
@@ -427,7 +428,7 @@ class SwarmTeam:
 
         try:
             output = self._parse_response(
-                content=response,
+                response=response,
                 response_format=response_format,
                 task_context=task_context,
             )

--- a/liteswarm/types/__init__.py
+++ b/liteswarm/types/__init__.py
@@ -11,7 +11,7 @@ from .llm import LLM, AgentTool
 from .misc import JSON, Number
 from .result import Result
 from .swarm import Agent, AgentInstructions, Delta, Message, ToolCallResult, ToolMessage
-from .swarm_team import Plan, Task, TaskDefinition, TaskResult, TeamMember
+from .swarm_team import Artifact, ArtifactStatus, Plan, Task, TaskDefinition, TaskResult, TeamMember
 
 __all__ = [
     "JSON",
@@ -19,6 +19,8 @@ __all__ = [
     "Agent",
     "AgentInstructions",
     "AgentTool",
+    "Artifact",
+    "ArtifactStatus",
     "ChatCompletionDeltaToolCall",
     "ContextVariables",
     "Delta",

--- a/liteswarm/types/swarm_team.py
+++ b/liteswarm/types/swarm_team.py
@@ -310,29 +310,6 @@ class TaskDefinition(BaseModel):
     )
 
 
-class PlanStatus(str, Enum):
-    """Status of a plan in its lifecycle.
-
-    Tracks the progression of a plan from creation through approval
-    to execution and completion.
-    """
-
-    DRAFT = "draft"
-    """Plan is created but not yet approved."""
-
-    APPROVED = "approved"
-    """Plan is approved and ready for execution."""
-
-    IN_PROGRESS = "in_progress"
-    """Plan is currently being executed."""
-
-    COMPLETED = "completed"
-    """All tasks in plan have completed successfully."""
-
-    FAILED = "failed"
-    """Plan execution has failed."""
-
-
 class Plan(BaseModel):
     """Plan consisting of ordered tasks with dependencies.
 
@@ -362,9 +339,6 @@ class Plan(BaseModel):
 
     tasks: Sequence[Task]
     """Tasks in this plan."""
-
-    status: PlanStatus = PlanStatus.DRAFT
-    """Current plan status."""
 
     metadata: dict[str, Any] = Field(default_factory=dict)
     """Additional plan metadata."""

--- a/liteswarm/types/swarm_team.py
+++ b/liteswarm/types/swarm_team.py
@@ -526,3 +526,80 @@ class TaskResult(BaseModel):
         arbitrary_types_allowed=True,
         use_attribute_docstrings=True,
     )
+
+
+class ArtifactStatus(str, Enum):
+    """Status of an execution artifact.
+
+    Tracks the progression of a planning and execution iteration
+    from creation through completion or failure.
+    """
+
+    CREATED = "created"
+    """Artifact is initialized."""
+
+    PLANNING = "planning"
+    """Plan is being created."""
+
+    EXECUTING = "executing"
+    """Plan is being executed."""
+
+    COMPLETED = "completed"
+    """Execution completed successfully."""
+
+    FAILED = "failed"
+    """Execution failed."""
+
+
+class Artifact(BaseModel):
+    """Record of a planning and execution iteration.
+
+    Captures the complete lifecycle of a single attempt to create and execute
+    a plan, including any errors that occurred.
+
+    Examples:
+        Track execution progress:
+            ```python
+            artifact = Artifact(
+                id="exec-1",
+                timestamp=datetime.now(),
+                plan=plan,
+                task_results=[
+                    TaskResult(
+                        task=review_task,
+                        content="Review completed",
+                        output=ReviewOutput(approved=True)
+                    )
+                ],
+                status=ArtifactStatus.COMPLETED
+            )
+
+            if artifact.status == ArtifactStatus.FAILED:
+                print(f"Execution failed: {artifact.error}")
+            else:
+                print(f"Completed {len(artifact.task_results)} tasks")
+            ```
+    """
+
+    id: str
+    """Unique identifier for this artifact."""
+
+    timestamp: datetime = Field(default_factory=datetime.now)
+    """When this artifact was created."""
+
+    plan: Plan | None = None
+    """Plan that was executed."""
+
+    task_results: list[TaskResult] = Field(default_factory=list)
+    """Results from executed tasks."""
+
+    error: Exception | None = None
+    """Error if execution failed."""
+
+    status: ArtifactStatus = ArtifactStatus.CREATED
+    """Current status of this artifact."""
+
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_attribute_docstrings=True,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,14 +66,15 @@ select = [
     "UP",     # pyupgrade
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
-
-[tool.ruff.lint.pydocstyle]
-convention = "google"
+docstring-code-format = true
 
 [tool.mypy]
 python_version = "3.11"


### PR DESCRIPTION
# What
<!-- What changes are being made? Keep it brief and clear -->

- Introduce Artifact as the primary execution result model in SwarmTeam
- Update software_team example to demonstrate artifact usage

# Why
<!-- Why are these changes needed? What problem does it solve? -->

- Simplify execution result handling with a single, well-defined model
- Improve DX through:
  - Consistent error handling pattern
  - Better access to partial execution results
  - More intuitive status checking
  - Cleaner API without Result wrapping

# Scope Check
- [x] Changes are focused (no scope creep)
- [x] Less than 500 lines changed
- [x] Core functionality only (no nice-to-have features)
- [ ] Tests added/updated
- [x] Documentation added/updated

# Future Improvements
<!-- What was intentionally left out? List quick notes for future -->

- Add artifact persistence/serialization
- Consider metrics/telemetry in artifacts
- Add artifact history/versioning support
- Implement plan feedback loop mechanism (separate PR)

# Self Review
- [x] PR is small and focused
- [x] Commits are clear and logical
- [x] No debug code left
- [x] Tested locally