### PR TITLE
refactor(swarm_team): rename agent planner to follow agent naming convention

### DIFF
--- a/examples/software_team/planner.py
+++ b/examples/software_team/planner.py
@@ -5,7 +5,7 @@
 # https://opensource.org/licenses/MIT.
 
 from liteswarm.core import Swarm
-from liteswarm.experimental import AgentPlanner, LiteAgentPlanner
+from liteswarm.experimental import LitePlanningAgent, PlanningAgent
 from liteswarm.types import JSON, LLM, Agent, ContextVariables, TaskDefinition
 
 from .types import FlutterTask, SoftwarePlan
@@ -149,7 +149,7 @@ def parse_planner_response(response: str, context: ContextVariables) -> Software
     return SoftwarePlan.model_validate(json_response)
 
 
-def create_agent_planner(swarm: Swarm, task_definitions: list[TaskDefinition]) -> AgentPlanner:
+def create_planning_agent(swarm: Swarm, task_definitions: list[TaskDefinition]) -> PlanningAgent:
     """Create a software planning agent."""
     agent = Agent(
         id="planner",
@@ -157,7 +157,7 @@ def create_agent_planner(swarm: Swarm, task_definitions: list[TaskDefinition]) -
         llm=LLM(model="claude-3-5-sonnet-20241022"),
     )
 
-    return LiteAgentPlanner(
+    return LitePlanningAgent(
         swarm=swarm,
         agent=agent,
         prompt_template=build_planner_user_prompt,

--- a/examples/software_team/planning.py
+++ b/examples/software_team/planning.py
@@ -11,7 +11,7 @@ from liteswarm.types import JSON, LLM, Agent, ContextVariables, TaskDefinition
 from .types import FlutterTask, SoftwarePlan
 from .utils import dump_json, find_json_tag
 
-AGENT_PLANNER_SYSTEM_PROMPT = """
+PLANNING_AGENT_SYSTEM_PROMPT = """
 You are an advanced AI Software Planning Agent designed to assist software engineering teams in project planning and task management. Your primary function is to analyze user queries, decompose them into actionable tasks, and generate a structured plan that can be executed by development teams across various technologies and frameworks.
 
 ### Project Context
@@ -85,7 +85,7 @@ Example Response Structure:
 </example_response>
 """.strip()
 
-AGENT_PLANNER_USER_PROMPT = """
+PLANNING_AGENT_USER_PROMPT = """
 Please create a development plan for this request:
 
 <user_request>
@@ -102,8 +102,8 @@ Now proceed to create a development plan for the user's request.
 """.strip()
 
 
-def build_planner_system_prompt(context: ContextVariables) -> str:
-    """Build system prompt for the plan agent."""
+def build_planning_agent_system_prompt(context: ContextVariables) -> str:
+    """Build system prompt for the planning agent."""
     project_directories: JSON = context.get("directories", [])
     project_files: JSON = context.get("files", [])
     tech_stack: JSON = context.get("tech_stack", {})
@@ -120,7 +120,7 @@ def build_planner_system_prompt(context: ContextVariables) -> str:
         ]
     )
 
-    return AGENT_PLANNER_SYSTEM_PROMPT.format(
+    return PLANNING_AGENT_SYSTEM_PROMPT.format(
         PROJECT_DIRECTORIES=dump_json(project_directories),
         PROJECT_FILES=dump_json(project_files),
         TECH_STACK=dump_json(tech_stack),
@@ -130,18 +130,18 @@ def build_planner_system_prompt(context: ContextVariables) -> str:
     )
 
 
-def build_planner_user_prompt(prompt: str, context: ContextVariables) -> str:
-    """Build user prompt for the plan agent."""
+def build_planning_agent_user_prompt(prompt: str, context: ContextVariables) -> str:
+    """Build user prompt for the planning agent."""
     project_context: JSON = context.get("project", {})
 
-    return AGENT_PLANNER_USER_PROMPT.format(
+    return PLANNING_AGENT_USER_PROMPT.format(
         USER_PROMPT=prompt,
         CONTEXT=dump_json(project_context),
     )
 
 
-def parse_planner_response(response: str, context: ContextVariables) -> SoftwarePlan:
-    """Parse the response from the planner agent."""
+def parse_planning_agent_response(response: str, context: ContextVariables) -> SoftwarePlan:
+    """Parse the response from the planning agent."""
     json_response = find_json_tag(response, "json_response")
     if not json_response:
         raise ValueError("No JSON response found")
@@ -153,14 +153,14 @@ def create_planning_agent(swarm: Swarm, task_definitions: list[TaskDefinition]) 
     """Create a software planning agent."""
     agent = Agent(
         id="planner",
-        instructions=build_planner_system_prompt,
+        instructions=build_planning_agent_system_prompt,
         llm=LLM(model="claude-3-5-sonnet-20241022"),
     )
 
     return LitePlanningAgent(
         swarm=swarm,
         agent=agent,
-        prompt_template=build_planner_user_prompt,
-        response_format=parse_planner_response,
+        prompt_template=build_planning_agent_user_prompt,
+        response_format=parse_planning_agent_response,
         task_definitions=task_definitions,
     )

--- a/examples/software_team/run.py
+++ b/examples/software_team/run.py
@@ -13,7 +13,7 @@ from liteswarm.types import ArtifactStatus
 from liteswarm.utils import enable_logging
 
 from .handlers import InteractivePlanFeedbackHandler, SwarmStreamHandler, SwarmTeamStreamHandler
-from .planner import create_agent_planner
+from .planner import create_planning_agent
 from .tasks import create_task_definitions
 from .team import create_team_members
 from .types import FileContent, Project
@@ -92,13 +92,13 @@ def create_team() -> SwarmTeam:
 
     task_definitions = create_task_definitions()
     team_members = create_team_members()
-    agent_planner = create_agent_planner(swarm, task_definitions)
+    planning_agent = create_planning_agent(swarm, task_definitions)
 
     team = SwarmTeam(
         swarm=swarm,
         members=team_members,
         task_definitions=task_definitions,
-        agent_planner=agent_planner,
+        planning_agent=planning_agent,
         stream_handler=SwarmTeamStreamHandler(),
     )
 

--- a/examples/software_team/run.py
+++ b/examples/software_team/run.py
@@ -13,7 +13,7 @@ from liteswarm.types import ArtifactStatus
 from liteswarm.utils import enable_logging
 
 from .handlers import InteractivePlanFeedbackHandler, SwarmStreamHandler, SwarmTeamStreamHandler
-from .planner import create_planning_agent
+from .planning import create_planning_agent
 from .tasks import create_task_definitions
 from .team import create_team_members
 from .types import FileContent, Project

--- a/liteswarm/__init__.py
+++ b/liteswarm/__init__.py
@@ -5,13 +5,13 @@
 # https://opensource.org/licenses/MIT.
 
 from .core import Swarm
-from .experimental import AgentPlanner, LiteAgentPlanner, SwarmTeam
+from .experimental import LitePlanningAgent, PlanningAgent, SwarmTeam
 from .repl import AgentRepl, start_repl
 
 __all__ = [
-    "AgentPlanner",
     "AgentRepl",
-    "LiteAgentPlanner",
+    "LitePlanningAgent",
+    "PlanningAgent",
     "Swarm",
     "SwarmTeam",
     "start_repl",

--- a/liteswarm/experimental/__init__.py
+++ b/liteswarm/experimental/__init__.py
@@ -5,18 +5,18 @@
 # https://opensource.org/licenses/MIT.
 
 from .swarm_team import (
-    AgentPlanner,
-    LiteAgentPlanner,
+    LitePlanningAgent,
     LiteSwarmTeamStreamHandler,
+    PlanningAgent,
     PromptTemplate,
     SwarmTeam,
     SwarmTeamStreamHandler,
 )
 
 __all__ = [
-    "AgentPlanner",
-    "LiteAgentPlanner",
+    "LitePlanningAgent",
     "LiteSwarmTeamStreamHandler",
+    "PlanningAgent",
     "PromptTemplate",
     "SwarmTeam",
     "SwarmTeamStreamHandler",

--- a/liteswarm/experimental/swarm_team/__init__.py
+++ b/liteswarm/experimental/swarm_team/__init__.py
@@ -4,14 +4,14 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-from .planner import AgentPlanner, LiteAgentPlanner, PromptTemplate
+from .planning import LitePlanningAgent, PlanningAgent, PromptTemplate
 from .stream_handler import LiteSwarmTeamStreamHandler, SwarmTeamStreamHandler
 from .swarm_team import SwarmTeam
 
 __all__ = [
-    "AgentPlanner",
-    "LiteAgentPlanner",
+    "LitePlanningAgent",
     "LiteSwarmTeamStreamHandler",
+    "PlanningAgent",
     "PromptTemplate",
     "SwarmTeam",
     "SwarmTeamStreamHandler",

--- a/liteswarm/experimental/swarm_team/planning.py
+++ b/liteswarm/experimental/swarm_team/planning.py
@@ -40,7 +40,7 @@ Follow the output format specified in the prompt to create your plan.
 """.strip()
 
 
-class AgentPlanner(Protocol):
+class PlanningAgent(Protocol):
     """Protocol for agents that create task plans.
 
     Defines the interface for planning agents that can analyze prompts and create
@@ -49,7 +49,7 @@ class AgentPlanner(Protocol):
     Examples:
         Create a custom planner:
             ```python
-            class CustomPlanner(AgentPlanner):
+            class CustomPlanningAgent(PlanningAgent):
                 async def create_plan(
                     self,
                     prompt: str,
@@ -81,7 +81,7 @@ class AgentPlanner(Protocol):
         ...
 
 
-class LiteAgentPlanner(AgentPlanner):
+class LitePlanningAgent(PlanningAgent):
     """LLM-based implementation of the planning protocol.
 
     Uses an LLM agent to analyze requirements and generate structured plans,
@@ -103,7 +103,7 @@ class LiteAgentPlanner(AgentPlanner):
             )
 
             # Initialize planner
-            planner = LiteAgentPlanner(
+            planner = LitePlanningAgent(
                 swarm=swarm,
                 agent=Agent(id="planner", llm=LLM(model="gpt-4o")),
                 task_definitions=[review_def],
@@ -160,7 +160,7 @@ class LiteAgentPlanner(AgentPlanner):
         Examples:
             Basic usage:
                 ```python
-                planner = LiteAgentPlanner(swarm=swarm)
+                planner = LitePlanningAgent(swarm=swarm)
                 repair_agent = planner._default_response_repair_agent()
                 assert isinstance(repair_agent, LiteResponseRepairAgent)
                 ```
@@ -172,7 +172,7 @@ class LiteAgentPlanner(AgentPlanner):
                         # Custom repair logic
                         pass
 
-                planner = LiteAgentPlanner(
+                planner = LitePlanningAgent(
                     swarm=swarm,
                     response_repair_agent=CustomRepairAgent(),
                 )
@@ -199,7 +199,7 @@ class LiteAgentPlanner(AgentPlanner):
 
             Use in planner:
                 ```python
-                planner = LiteAgentPlanner(swarm=swarm)
+                planner = LitePlanningAgent(swarm=swarm)
                 # Automatically creates default agent if none provided
                 assert planner.agent.id == "agent-planner"
                 assert planner.agent.llm.model == "gpt-4o"
@@ -231,7 +231,7 @@ class LiteAgentPlanner(AgentPlanner):
                     return f"{prompt} for {context.get('project_name')}"
 
 
-                planner = LiteAgentPlanner(swarm=swarm, prompt_template=custom_template)
+                planner = LitePlanningAgent(swarm=swarm, prompt_template=custom_template)
                 # Will format prompts with project name
                 ```
         """
@@ -247,7 +247,7 @@ class LiteAgentPlanner(AgentPlanner):
             Default format:
                 ```python
                 # With review and test task types
-                planner = LiteAgentPlanner(swarm=swarm, task_definitions=[review_def, test_def])
+                planner = LitePlanningAgent(swarm=swarm, task_definitions=[review_def, test_def])
                 format = planner._default_planning_response_format()
                 # Returns Plan schema that accepts:
                 # - ReviewTask
@@ -261,7 +261,7 @@ class LiteAgentPlanner(AgentPlanner):
                     return Plan(tasks=[...])
 
 
-                planner = LiteAgentPlanner(swarm=swarm, response_format=parse_plan)
+                planner = LitePlanningAgent(swarm=swarm, response_format=parse_plan)
                 # Will use custom parser instead of schema
                 ```
         """
@@ -626,7 +626,7 @@ class LiteAgentPlanner(AgentPlanner):
             Custom template:
                 ```python
                 # With custom prompt template
-                planner = LiteAgentPlanner(
+                planner = LitePlanningAgent(
                     swarm=swarm,
                     prompt_template=lambda p, c: f"{p} for {c.get('project')}",
                     task_definitions=[review_def, test_def],

--- a/liteswarm/experimental/swarm_team/swarm_team.py
+++ b/liteswarm/experimental/swarm_team/swarm_team.py
@@ -11,7 +11,7 @@ import json_repair
 from pydantic import BaseModel, ValidationError
 
 from liteswarm.core.swarm import Swarm
-from liteswarm.experimental.swarm_team.planner import AgentPlanner, LiteAgentPlanner
+from liteswarm.experimental.swarm_team.planning import LitePlanningAgent, PlanningAgent
 from liteswarm.experimental.swarm_team.registry import TaskRegistry
 from liteswarm.experimental.swarm_team.response_repair import (
     LiteResponseRepairAgent,
@@ -87,7 +87,7 @@ class SwarmTeam:
         swarm: Swarm,
         members: list[TeamMember],
         task_definitions: list[TaskDefinition],
-        agent_planner: AgentPlanner | None = None,
+        planning_agent: PlanningAgent | None = None,
         response_repair_agent: ResponseRepairAgent | None = None,
         stream_handler: SwarmTeamStreamHandler | None = None,
     ) -> None:
@@ -97,7 +97,7 @@ class SwarmTeam:
             swarm: Swarm client for agent interactions.
             members: Team members with their capabilities.
             task_definitions: Task types the team can handle.
-            agent_planner: Optional custom planning agent.
+            planning_agent: Optional custom planning agent.
             response_repair_agent: Optional custom response repair agent.
             stream_handler: Optional event stream handler.
         """
@@ -105,7 +105,7 @@ class SwarmTeam:
         self.swarm = swarm
         self.members = {member.agent.id: member for member in members}
         self.stream_handler = stream_handler
-        self.agent_planner = agent_planner or LiteAgentPlanner(
+        self.planning_agent = planning_agent or LitePlanningAgent(
             swarm=self.swarm,
             task_definitions=task_definitions,
         )
@@ -559,7 +559,7 @@ class SwarmTeam:
         if context:
             self._context.update(context)
 
-        result = await self.agent_planner.create_plan(
+        result = await self.planning_agent.create_plan(
             prompt=prompt,
             context=self._context,
         )


### PR DESCRIPTION
# What
<!-- What changes are being made? Keep it brief and clear -->

- Rename AgentPlanner to PlanningAgent and related files/classes for consistency

# Why
<!-- Why are these changes needed? What problem does it solve? -->

- Current naming is inconsistent with codebase conventions and unclear in its purpose

# Scope Check
- [x] Changes are focused (no scope creep)
- [x] Less than 500 lines changed
- [ ] Core functionality only (no nice-to-have features)
- [ ] Tests added/updated
- [x] Documentation added/updated

# Future Improvements
<!-- What was intentionally left out? List quick notes for future -->

# Self Review
- [x] PR is small and focused
- [x] Commits are clear and logical
- [x] No debug code left
- [x] Tested locally
