### PR TITLE
feat: return context in Swarm and SwarmTeam

### DIFF
--- a/liteswarm/core/swarm.py
+++ b/liteswarm/core/swarm.py
@@ -1443,6 +1443,7 @@ class Swarm:
             agent_messages=self._agent_messages,
             agent_queue=list(self._agent_queue),
             messages=self._full_history,
+            context_variables=self._context_variables,
             usage=full_usage,
             response_cost=response_cost,
         )

--- a/liteswarm/experimental/swarm_team/swarm_team.py
+++ b/liteswarm/experimental/swarm_team/swarm_team.py
@@ -495,6 +495,7 @@ class SwarmTeam:
             task_result = TaskResult(
                 task=task,
                 content=response,
+                context=task_context,
                 assignee=assignee,
             )
 
@@ -511,6 +512,7 @@ class SwarmTeam:
                 task=task,
                 content=response,
                 output=output,
+                context=task_context,
                 assignee=assignee,
             )
 
@@ -529,6 +531,7 @@ class SwarmTeam:
                 task=task,
                 content=response,
                 output=repaired_response,
+                context=task_context,
                 assignee=assignee,
             )
 
@@ -901,6 +904,9 @@ class SwarmTeam:
 
             if not result.content:
                 raise ValueError("The agent did not return any content")
+
+            if result.context_variables:
+                task_context.update(result.context_variables)
 
             task.status = TaskStatus.COMPLETED
             task_result = await self._process_response(

--- a/liteswarm/types/swarm.py
+++ b/liteswarm/types/swarm.py
@@ -687,6 +687,9 @@ class ConversationState(BaseModel):
     messages: list[Message] = Field(default_factory=list)
     """Complete conversation history."""
 
+    context_variables: ContextVariables | None = None
+    """Current context variables."""
+
     usage: Usage | None = None
     """Total token usage."""
 

--- a/liteswarm/types/swarm.py
+++ b/liteswarm/types/swarm.py
@@ -663,6 +663,10 @@ class ConversationState(BaseModel):
                 ],
                 agent_queue=[backup_agent],  # Queued agents
                 messages=[],  # Full history
+                context_variables=ContextVariables(
+                    user_name="John",
+                    language="English",
+                ),
                 usage=Usage(total_tokens=100),
                 response_cost=ResponseCost(
                     prompt_tokens_cost=0.001,

--- a/liteswarm/types/swarm.py
+++ b/liteswarm/types/swarm.py
@@ -703,4 +703,5 @@ class ConversationState(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         use_attribute_docstrings=True,
+        extra="forbid",
     )

--- a/liteswarm/types/swarm_team.py
+++ b/liteswarm/types/swarm_team.py
@@ -663,6 +663,7 @@ class TaskResult(BaseModel):
                     comments=["Good error handling", "Well documented"],
                     suggestions=[],
                 ),
+                context=ContextVariables(pr_url="github.com/org/repo/123"),
                 assignee=reviewer,
                 timestamp=datetime.now(),
             )
@@ -682,6 +683,9 @@ class TaskResult(BaseModel):
 
     output: BaseModel | None = None
     """Structured output data."""
+
+    context: ContextVariables | None = None
+    """Context variables for the task."""
 
     assignee: TeamMember | None = None
     """Member who executed the task."""


### PR DESCRIPTION
# What
- Add context variables support to ConversationState and TaskResult models
- Propagate context variables through task execution flow

# Why
- Enable tracking and passing context between different parts of the liteswarm system
- Allow tasks to maintain and update their context during execution

# Scope Check
- [x] Changes are focused (no scope creep)
- [x] Less than 500 lines changed
- [x] Core functionality only (no nice-to-have features)
- [ ] Tests added/updated
- [x] Documentation added/updated

# Future Improvements

# Self Review
- [x] PR is small and focused
- [x] Commits are clear and logical
- [x] No debug code left
- [x] Tested locally