### PR TITLE
fix(core): fix duplicate keys error when updating context variables

### DIFF
--- a/examples/software_team/utils.py
+++ b/examples/software_team/utils.py
@@ -169,4 +169,4 @@ def create_context_from_project(project: Project) -> ContextVariables:
         context = create_context_from_project(project)
         ```
     """
-    return ContextVariables(**project.model_dump())
+    return ContextVariables(project.model_dump())

--- a/liteswarm/core/swarm.py
+++ b/liteswarm/core/swarm.py
@@ -907,10 +907,7 @@ class Swarm:
                     self._agent_queue.append(tool_message.agent)
 
                 if tool_message.context_variables:
-                    self._context_variables = ContextVariables(
-                        **self._context_variables,
-                        **tool_message.context_variables,
-                    )
+                    self._context_variables.update(tool_message.context_variables)
 
                 messages.append(tool_message.message)
 


### PR DESCRIPTION
# What
<!-- What changes are being made? Keep it brief and clear -->
- Fix dict unpacking error in ContextVariables when keys collide

# Why
<!-- Why are these changes needed? What problem does it solve? -->
- Prevents crashes when merging context variables with duplicate keys

# Scope Check
- [x] Changes are focused (no scope creep)
- [x] Less than 500 lines changed
- [x] Core functionality only
- [ ] Tests added/updated
- [x] Documentation added/updated

# Future Improvements
<!-- What was intentionally left out? List quick notes for future -->

# Self Review
- [x] PR is small and focused
- [x] Commits are clear and logical
- [x] No debug code left
- [x] Tested locally